### PR TITLE
Remove the extra SD_WEBP macro define. Since now we move to a dedicated repo

### DIFF
--- a/Example/SDWebImageWebPCoderExample.xcodeproj/project.pbxproj
+++ b/Example/SDWebImageWebPCoderExample.xcodeproj/project.pbxproj
@@ -169,15 +169,11 @@
 			buildActionMask = 2147483647;
 			files = (
 			);
-			inputFileListPaths = (
-			);
 			inputPaths = (
 				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
 				"${PODS_ROOT}/Manifest.lock",
 			);
 			name = "[CP] Check Pods Manifest.lock";
-			outputFileListPaths = (
-			);
 			outputPaths = (
 				"$(DERIVED_FILE_DIR)/Pods-SDWebImageWebPCoderExample-checkManifestLockResult.txt",
 			);
@@ -191,8 +187,6 @@
 			buildActionMask = 2147483647;
 			files = (
 			);
-			inputFileListPaths = (
-			);
 			inputPaths = (
 				"${SRCROOT}/Pods/Target Support Files/Pods-SDWebImageWebPCoderExample/Pods-SDWebImageWebPCoderExample-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/SDWebImage/SDWebImage.framework",
@@ -200,8 +194,6 @@
 				"${BUILT_PRODUCTS_DIR}/libwebp/libwebp.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-			);
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SDWebImage.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SDWebImageWebPCoder.framework",

--- a/SDWebImageWebPCoder.xcodeproj/project.pbxproj
+++ b/SDWebImageWebPCoder.xcodeproj/project.pbxproj
@@ -485,8 +485,6 @@
 			buildActionMask = 2147483647;
 			files = (
 			);
-			inputFileListPaths = (
-			);
 			inputPaths = (
 				"${SRCROOT}/SDWebImageWebPCoderTests/Pods/Target Support Files/Pods-SDWebImageWebPCoderTests/Pods-SDWebImageWebPCoderTests-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/SDWebImage/SDWebImage.framework",
@@ -494,8 +492,6 @@
 				"${BUILT_PRODUCTS_DIR}/libwebp/libwebp.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-			);
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SDWebImage.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SDWebImageWebPCoder.framework",
@@ -511,15 +507,11 @@
 			buildActionMask = 2147483647;
 			files = (
 			);
-			inputFileListPaths = (
-			);
 			inputPaths = (
 				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
 				"${PODS_ROOT}/Manifest.lock",
 			);
 			name = "[CP] Check Pods Manifest.lock";
-			outputFileListPaths = (
-			);
 			outputPaths = (
 				"$(DERIVED_FILE_DIR)/Pods-SDWebImageWebPCoderTests-checkManifestLockResult.txt",
 			);
@@ -624,11 +616,16 @@
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
-					"SD_WEBP=1",
 					"$(inherited)",
 				);
-				"GCC_PREPROCESSOR_DEFINITIONS[sdk=watchos*]" = "WEBP_USE_INTRINSICS=1 $(inherited)";
-				"GCC_PREPROCESSOR_DEFINITIONS[sdk=watchsimulator*]" = "WEBP_USE_INTRINSICS=1 $(inherited)";
+				"GCC_PREPROCESSOR_DEFINITIONS[sdk=watchos*]" = (
+					"WEBP_USE_INTRINSICS=1",
+					"$(inherited)",
+				);
+				"GCC_PREPROCESSOR_DEFINITIONS[sdk=watchsimulator*]" = (
+					"WEBP_USE_INTRINSICS=1",
+					"$(inherited)",
+				);
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_UNDECLARED_SELECTOR = YES;
@@ -695,12 +692,15 @@
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_NO_COMMON_BLOCKS = YES;
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					"SD_WEBP=1",
+				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
+				"GCC_PREPROCESSOR_DEFINITIONS[sdk=watchos*]" = (
+					"WEBP_USE_INTRINSICS=1",
 					"$(inherited)",
 				);
-				"GCC_PREPROCESSOR_DEFINITIONS[sdk=watchos*]" = "WEBP_USE_INTRINSICS=1 $(inherited)";
-				"GCC_PREPROCESSOR_DEFINITIONS[sdk=watchsimulator*]" = "WEBP_USE_INTRINSICS=1 $(inherited)";
+				"GCC_PREPROCESSOR_DEFINITIONS[sdk=watchsimulator*]" = (
+					"WEBP_USE_INTRINSICS=1",
+					"$(inherited)",
+				);
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_UNDECLARED_SELECTOR = YES;

--- a/SDWebImageWebPCoder.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/SDWebImageWebPCoder.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/SDWebImageWebPCoder/Classes/SDImageWebPCoder.h
+++ b/SDWebImageWebPCoder/Classes/SDImageWebPCoder.h
@@ -6,8 +6,6 @@
  * file that was distributed with this source code.
  */
 
-#ifdef SD_WEBP
-
 #import <Foundation/Foundation.h>
 #import <SDWebImage/SDImageCoder.h>
 
@@ -19,5 +17,3 @@
 @property (nonatomic, class, readonly, nonnull) SDImageWebPCoder *sharedCoder;
 
 @end
-
-#endif

--- a/SDWebImageWebPCoder/Classes/SDImageWebPCoder.m
+++ b/SDWebImageWebPCoder/Classes/SDImageWebPCoder.m
@@ -6,8 +6,6 @@
  * file that was distributed with this source code.
  */
 
-#ifdef SD_WEBP
-
 #import "SDImageWebPCoder.h"
 #import <SDWebImage/SDImageCoderHelper.h>
 #if __has_include(<SDWebImage/NSImage+Compatibility.h>)
@@ -29,6 +27,14 @@
 #endif
 
 #import <Accelerate/Accelerate.h>
+
+#ifndef SD_LOCK
+#define SD_LOCK(lock) dispatch_semaphore_wait(lock, DISPATCH_TIME_FOREVER);
+#endif
+
+#ifndef SD_UNLOCK
+#define SD_UNLOCK(lock) dispatch_semaphore_signal(lock);
+#endif
 
 @interface SDWebPCoderFrame : NSObject
 
@@ -748,9 +754,9 @@ static void FreeImageData(void *info, const void *data, size_t size) {
     if (index >= _frameCount) {
         return nil;
     }
-    LOCKBLOCK({
-        image = [self safeAnimatedImageFrameAtIndex:index];
-    });
+    SD_LOCK(_lock);
+    image = [self safeAnimatedImageFrameAtIndex:index];
+    SD_UNLOCK(_lock);
     return image;
 }
 
@@ -826,6 +832,3 @@ static void FreeImageData(void *info, const void *data, size_t size) {
 }
 
 @end
-
-#endif
-

--- a/SDWebImageWebPCoder/Classes/UIImage+WebP.h
+++ b/SDWebImageWebPCoder/Classes/UIImage+WebP.h
@@ -6,8 +6,6 @@
  * file that was distributed with this source code.
  */
 
-#ifdef SD_WEBP
-
 #import <SDWebImage/SDWebImageCompat.h>
 
 // This category is just use as a convenience method. For more detail control, use methods in `UIImage+MultiFormat.h` or directlly use `SDImageCoder`
@@ -23,5 +21,3 @@
 + (nullable UIImage *)sd_imageWithWebPData:(nullable NSData *)data;
 
 @end
-
-#endif

--- a/SDWebImageWebPCoder/Classes/UIImage+WebP.m
+++ b/SDWebImageWebPCoder/Classes/UIImage+WebP.m
@@ -6,8 +6,6 @@
  * file that was distributed with this source code.
  */
 
-#ifdef SD_WEBP
-
 #import "UIImage+WebP.h"
 #import "SDImageWebPCoder.h"
 
@@ -21,5 +19,3 @@
 }
 
 @end
-
-#endif


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: ...

### Pull Request Description

In previous version of SDWebImage, we define a macro `SD_WEBP` to indicate that we supports WebP image and link libwebp third party dependency. Using the macro can avoid actually generate the unused class symbols and files for user who don't need webp (Which may increase the framework binary size).

However, now, we move the `SDImageWebPCoder` into this dedicated repo. So this means, people who add dependency to our new repo indeed want WebP supports. Thoes `SD_WEBP` macro define does not do anything.

It's not time to remove them, to avoid unused extra process for some user (For example, in the previous version, if you need to build a embedded framework link the `SDWebImage/WebP`, you also to inherit this `SD_WEBP` macro in the Xcode project)