### PR TITLE
Fix the potential leak of chunk iterator used for ICC Profile colorSpace check

### DIFF
--- a/SDWebImageWebPCoder/Classes/SDImageWebPCoder.m
+++ b/SDWebImageWebPCoder/Classes/SDImageWebPCoder.m
@@ -422,13 +422,17 @@
     // WebP contains ICC Profile should use the desired colorspace, instead of default device colorspace
     // See: https://developers.google.com/speed/webp/docs/riff_container#color_profile
     
-    WebPChunkIterator chunk_iter;
     CGColorSpaceRef colorSpaceRef = NULL;
+    uint32_t flags = WebPDemuxGetI(demuxer, WEBP_FF_FORMAT_FLAGS);
     
-    int result = WebPDemuxGetChunk(demuxer, "ICCP", 1, &chunk_iter);
-    if (result) {
-        NSData *profileData = [NSData dataWithBytes:chunk_iter.chunk.bytes length:chunk_iter.chunk.size];
-        colorSpaceRef = CGColorSpaceCreateWithICCProfile((__bridge CFDataRef)profileData);
+    if (flags & ICCP_FLAG) {
+        WebPChunkIterator chunk_iter;
+        int result = WebPDemuxGetChunk(demuxer, "ICCP", 1, &chunk_iter);
+        if (result) {
+            NSData *profileData = [NSData dataWithBytesNoCopy:(void *)chunk_iter.chunk.bytes length:chunk_iter.chunk.size freeWhenDone:NO];
+            colorSpaceRef = CGColorSpaceCreateWithICCProfile((__bridge CFDataRef)profileData);
+            WebPDemuxReleaseChunkIterator(&chunk_iter);
+        }
     }
     
     if (!colorSpaceRef) {


### PR DESCRIPTION
This fix the potential leak of `WebPChunkIterator`. The libwebp says: 

> // Call WebPDemuxReleaseChunkIterator() when use of the iterator is complete.

This also imporve the performance by checking the ICC flags before actual grab the chunk.