### PR TITLE
Fix one leak of vImageConvertor

### DIFF
--- a/SDWebImageWebPCoder/Classes/SDImageWebPCoder.m
+++ b/SDWebImageWebPCoder/Classes/SDImageWebPCoder.m
@@ -595,12 +595,14 @@
         
         error = vImageBuffer_Init(&dest, height, width, destFormat.bitsPerPixel, kvImageNoFlags);
         if (error != kvImageNoError) {
+            vImageConverter_Release(convertor);
             CFRelease(dataRef);
             return nil;
         }
         
         // Convert input color mode to RGB888/RGBA8888
         error = vImageConvert_AnyToAny(convertor, &src, &dest, NULL, kvImageNoFlags);
+        vImageConverter_Release(convertor);
         if (error != kvImageNoError) {
             CFRelease(dataRef);
             return nil;


### PR DESCRIPTION
The `vImageConvert`, should be release after the usage. However, current code does not and cause a small leakage.

See documentation here of `vImageConverter_CreateWithCGImageFormat`:

```
*  @return  A vImageConverter object with reference count of 1 is created. If the call fails due to an error, then NULL
*  will be returned. Use vImageConverter_Release to release your reference to it and allow the resources used
*  by the converter to be returned to the system.
```