### PR TITLE
Fix the umbrella headers and modulemap for CocoaPods

### DIFF
--- a/Example/SDWebImageWebPCoderExample/ViewController.m
+++ b/Example/SDWebImageWebPCoderExample/ViewController.m
@@ -7,7 +7,7 @@
  */
 
 #import "ViewController.h"
-#import <SDWebImageWebPCoder/SDImageWebPCoder.h>
+#import <SDWebImageWebPCoder/SDWebImageWebPCoder.h>
 #import <SDWebImage/SDWebImage.h>
 
 @interface ViewController ()

--- a/SDWebImageWebPCoder.podspec
+++ b/SDWebImageWebPCoder.podspec
@@ -16,8 +16,9 @@ This is a simple SDWebImage coder plugin to support WebP image.
   s.osx.deployment_target = '10.10'
   s.tvos.deployment_target = '9.0'
   s.watchos.deployment_target = '2.0'
+  s.module_map = 'SDWebImageWebPCoder/Module/SDWebImageWebPCoder.modulemap'
   
-  s.source_files = 'SDWebImageWebPCoder/Classes/**/*'
+  s.source_files = 'SDWebImageWebPCoder/Classes/**/*', 'SDWebImageWebPCoder/Module/SDWebImageWebPCoder.h'
   s.xcconfig = {
     'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) SD_WEBP=1',
     'USER_HEADER_SEARCH_PATHS' => '$(inherited) $(SRCROOT)/libwebp/src'

--- a/SDWebImageWebPCoder.xcodeproj/project.pbxproj
+++ b/SDWebImageWebPCoder.xcodeproj/project.pbxproj
@@ -43,6 +43,7 @@
 
 /* Begin PBXFileReference section */
 		28D8AA3D3015E075692FD3E3 /* Pods-SDWebImageWebPCoderTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SDWebImageWebPCoderTests.debug.xcconfig"; path = "SDWebImageWebPCoderTests/Pods/Target Support Files/Pods-SDWebImageWebPCoderTests/Pods-SDWebImageWebPCoderTests.debug.xcconfig"; sourceTree = "<group>"; };
+		3217BE7B220547EB003D0310 /* SDWebImageWebPCoder.modulemap */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "sourcecode.module-map"; path = SDWebImageWebPCoder.modulemap; sourceTree = "<group>"; };
 		46F21AD7D1692EBAC4D0FF33 /* Pods_SDWebImageWebPCoderTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SDWebImageWebPCoderTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		806E779D2136A1C000A316D2 /* SDWebImageWebPCoder.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SDWebImageWebPCoder.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		806E77AA2136A2E900A316D2 /* UIImage+WebP.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIImage+WebP.m"; sourceTree = "<group>"; };
@@ -176,6 +177,7 @@
 			isa = PBXGroup;
 			children = (
 				806E77B02136A2E900A316D2 /* Info.plist */,
+				3217BE7B220547EB003D0310 /* SDWebImageWebPCoder.modulemap */,
 				806E77C62136A7AD00A316D2 /* SDWebImageWebPCoder.h */,
 			);
 			path = Module;

--- a/SDWebImageWebPCoder/Module/SDWebImageWebPCoder.modulemap
+++ b/SDWebImageWebPCoder/Module/SDWebImageWebPCoder.modulemap
@@ -1,0 +1,6 @@
+framework module SDWebImageWebPCoder {
+  umbrella header "SDWebImageWebPCoder.h"
+
+  export *
+  module * { export * }
+}


### PR DESCRIPTION
Fix that current SDWebImageWebP, does not including the standard umbrella header (Which should be `SDWebImageWebPCoder.h`). Seems that during migration the umbrella header is missed.