### PR TITLE
Fix that WebP with custom ICC Profile will randomly crash, because `CGColorSpaceCreateWithICCProfile` does not copy the ICC data pointer

### DIFF
--- a/SDWebImageWebPCoder/Classes/SDImageWebPCoder.m
+++ b/SDWebImageWebPCoder/Classes/SDImageWebPCoder.m
@@ -429,7 +429,9 @@
         WebPChunkIterator chunk_iter;
         int result = WebPDemuxGetChunk(demuxer, "ICCP", 1, &chunk_iter);
         if (result) {
-            NSData *profileData = [NSData dataWithBytesNoCopy:(void *)chunk_iter.chunk.bytes length:chunk_iter.chunk.size freeWhenDone:NO];
+            // See #2618, the `CGColorSpaceCreateWithICCProfile` does not copy ICC Profile data, it only retain the byte ptr.
+            // When the libwebp `WebPDemuxer` dealloc, all chunk will be freed. So we must copy the ICC data (really cheap, less than 10KB)
+            NSData *profileData = [NSData dataWithBytes:chunk_iter.chunk.bytes length:chunk_iter.chunk.size];
             colorSpaceRef = CGColorSpaceCreateWithICCProfile((__bridge CFDataRef)profileData);
             WebPDemuxReleaseChunkIterator(&chunk_iter);
         }


### PR DESCRIPTION
Review and See: https://github.com/SDWebImage/SDWebImage/pull/2621