### PR TITLE
Fix the issue when WebP contains the ICC Profile with colorSpace other than RGB, which cause the CGImageCreate failed

### DIFF
--- a/SDWebImageWebPCoder/Classes/SDImageWebPCoder.m
+++ b/SDWebImageWebPCoder/Classes/SDImageWebPCoder.m
@@ -434,6 +434,14 @@
             NSData *profileData = [NSData dataWithBytes:chunk_iter.chunk.bytes length:chunk_iter.chunk.size];
             colorSpaceRef = CGColorSpaceCreateWithICCProfile((__bridge CFDataRef)profileData);
             WebPDemuxReleaseChunkIterator(&chunk_iter);
+            if (colorSpaceRef) {
+                // `CGImageCreate` does not support colorSpace other than RGB (such as Monochrome), we must filter the colorSpace mode
+                CGColorSpaceModel model = CGColorSpaceGetModel(colorSpaceRef);
+                if (model != kCGColorSpaceModelRGB) {
+                    CGColorSpaceRelease(colorSpaceRef);
+                    colorSpaceRef = NULL;
+                }
+            }
         }
     }
     


### PR DESCRIPTION
See: https://github.com/SDWebImage/SDWebImage/pull/2627