### PR TITLE
Fix the issue that could not compile SDWebImageWebPCoder when using CocoaPods with use_modular_header!

### DIFF
--- a/SDWebImageWebPCoder/Classes/SDImageWebPCoder.h
+++ b/SDWebImageWebPCoder/Classes/SDImageWebPCoder.h
@@ -7,7 +7,7 @@
  */
 
 #import <Foundation/Foundation.h>
-#import <SDWebImage/SDImageCoder.h>
+@import SDWebImage;
 
 /**
  Built in coder that supports WebP and animated WebP

--- a/SDWebImageWebPCoder/Classes/UIImage+WebP.h
+++ b/SDWebImageWebPCoder/Classes/UIImage+WebP.h
@@ -6,8 +6,7 @@
  * file that was distributed with this source code.
  */
 
-@import UIKit;
-#import <SDWebImage/SDWebImageCompat.h>
+@import SDWebImage;
 
 // This category is just use as a convenience method. For more detail control, use methods in `UIImage+MultiFormat.h` or directlly use `SDImageCoder`
 @interface UIImage (WebP)

--- a/SDWebImageWebPCoder/Classes/UIImage+WebP.h
+++ b/SDWebImageWebPCoder/Classes/UIImage+WebP.h
@@ -6,6 +6,7 @@
  * file that was distributed with this source code.
  */
 
+@import UIKit;
 #import <SDWebImage/SDWebImageCompat.h>
 
 // This category is just use as a convenience method. For more detail control, use methods in `UIImage+MultiFormat.h` or directlly use `SDImageCoder`


### PR DESCRIPTION
Hi, I added `@import UIKit;` at `UIImage+WebP.h` to fix the issue that I mentioned at this PR's title.

The issue can be reproduced using a `Podfile` with `use_modular_headers!`, to link this library as a static library, as follows:

```
/<Your Project>/Pods/Headers/Public/SDWebImageWebPCoder/UIImage+WebP.h:12:12: Declaration of 'UIImage' must be imported from module 'UIKit.UIDocumentBrowserAction' before it is required
```
and
```
/<Your Project>/Pods/Headers/Public/SDWebImageWebPCoder/UIImage+WebP.h:12:12: Definition of 'UIImage' must be imported from module 'UIKit.UIImage' before it is required
```