### PR TITLE
Don't Read the ICC profile from the decoded image in the case we are on iOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ DerivedData/
 *.perspectivev3
 !default.perspectivev3
 xcuserdata/
+xcshareddata/
 
 ## Other
 *.moved-aside

--- a/SDWebImageWebPCoder.xcworkspace/contents.xcworkspacedata
+++ b/SDWebImageWebPCoder.xcworkspace/contents.xcworkspacedata
@@ -10,7 +10,4 @@
    <FileRef
       location = "group:SDWebImageWebPCoder.xcodeproj">
    </FileRef>
-   <FileRef
-      location = "group:SDWebImageWebPCoderTests/Pods/Pods.xcodeproj">
-   </FileRef>
 </Workspace>

--- a/SDWebImageWebPCoder.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/SDWebImageWebPCoder.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/SDWebImageWebPCoder.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/SDWebImageWebPCoder.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-	<key>IDEDidComputeMac32BitWarning</key>
-	<true/>
-</dict>
-</plist>

--- a/SDWebImageWebPCoder/Classes/SDImageWebPCoder.m
+++ b/SDWebImageWebPCoder/Classes/SDImageWebPCoder.m
@@ -419,10 +419,16 @@
 
 // Create and return the correct colorspace by checking the ICC Profile
 - (nonnull CGColorSpaceRef)sd_colorSpaceWithDemuxer:(nonnull WebPDemuxer *)demuxer CF_RETURNS_RETAINED {
+    CGColorSpaceRef colorSpaceRef = NULL;
+    #if SD_UIKIT || SD_WATCH
+        colorSpaceRef = [SDImageCoderHelper colorSpaceGetDeviceRGB];
+        CGColorSpaceRetain(colorSpaceRef);
+    return colorSpaceRef;
+    #else
     // WebP contains ICC Profile should use the desired colorspace, instead of default device colorspace
     // See: https://developers.google.com/speed/webp/docs/riff_container#color_profile
     
-    CGColorSpaceRef colorSpaceRef = NULL;
+    
     uint32_t flags = WebPDemuxGetI(demuxer, WEBP_FF_FORMAT_FLAGS);
     
     if (flags & ICCP_FLAG) {
@@ -451,6 +457,7 @@
     }
     
     return colorSpaceRef;
+    #endif
 }
 
 #pragma mark - Encode

--- a/SDWebImageWebPCoder/Classes/SDImageWebPCoder.m
+++ b/SDWebImageWebPCoder/Classes/SDImageWebPCoder.m
@@ -423,7 +423,7 @@
     #if SD_UIKIT || SD_WATCH
         colorSpaceRef = [SDImageCoderHelper colorSpaceGetDeviceRGB];
         CGColorSpaceRetain(colorSpaceRef);
-    return colorSpaceRef;
+        return colorSpaceRef;
     #else
     // WebP contains ICC Profile should use the desired colorspace, instead of default device colorspace
     // See: https://developers.google.com/speed/webp/docs/riff_container#color_profile


### PR DESCRIPTION
In iOS/Watch we don't need to read the ICC profile from the encoded image since iOS does not support device agnostic color spaces. 
Remove reference to empty project file