### PR TITLE
Fix the Animated WebP coder the frame blend index calculation issue, he end condition should be only `endIndex` to match the behavior.

### DIFF
--- a/SDWebImageWebPCoder/Classes/SDImageWebPCoder.m
+++ b/SDWebImageWebPCoder/Classes/SDImageWebPCoder.m
@@ -841,7 +841,7 @@ static void FreeImageData(void *info, const void *data, size_t size) {
                 @autoreleasepool {
                     [self sd_blendWebpImageWithCanvas:_canvas iterator:iter colorSpace:_colorSpace];
                 }
-            } while ((size_t)iter.frame_num < (endIndex + 1) && WebPDemuxNextFrame(&iter));
+            } while ((size_t)iter.frame_num < endIndex && WebPDemuxNextFrame(&iter));
         }
     }
     


### PR DESCRIPTION
### Issue

See Bug demo: https://github.com/krze/SDWebImage-WebP-Bug
Issue: https://github.com/SDWebImage/SDWebImage/issues/2835

### Bug Reason

I found the logic bug. The code comment does not match what it do.

```
// Draw from range: [startIndex, endIndex)
while ((size_t)iter.frame_num < endIndex && WebPDemuxNextFrame(&iter));
```

Before we call `WebPDemuxNextFrame`, the `iter.frame_num` is the 0-based previous frame index + 1. So the endIndex should not use `+1` as well.

For example:

request index == 1
frame.fromIndex == 0
frame.endIndex == 1

it should only call `sd_blendWebpImageWithCanvas` once, then call `sd_drawnWebpImageWithCanvas` once. But however, current code cause that call `sd_blendWebpImageWithCanvas` twice. This is the problem.

## Solution

Change the end condition of that while loop, should just check `< endIndex`