### PR TITLE
Fix the issue when WebP is static webp, the `SDAnimatedImageCoder` protocol implementation still create CGContext, this can reduce RAM usage

### DIFF
--- a/SDWebImageWebPCoderTests/SDWebImageWebPCoderTests.m
+++ b/SDWebImageWebPCoderTests/SDWebImageWebPCoderTests.m
@@ -10,6 +10,7 @@
 @import XCTest;
 #import <SDWebImage/SDWebImage.h>
 #import <SDWebImageWebPCoder/SDWebImageWebPCoder.h>
+#import <objc/runtime.h>
 
 const int64_t kAsyncTestTimeout = 5;
 
@@ -170,6 +171,18 @@ const int64_t kAsyncTestTimeout = 5;
                 break;
         }
     }
+}
+
+- (void)test34StaticImageNotCreateCGContext {
+    NSURL *staticWebPURL = [[NSBundle bundleForClass:[self class]] URLForResource:@"TestImageStatic" withExtension:@"webp"];
+    NSData *data = [NSData dataWithContentsOfURL:staticWebPURL];
+    SDImageWebPCoder *coder = [[SDImageWebPCoder alloc] initWithAnimatedImageData:data options:nil];
+    XCTAssertTrue(coder.animatedImageFrameCount == 1);
+    UIImage *image = [coder animatedImageFrameAtIndex:0];
+    XCTAssertNotNil(image);
+    Ivar ivar = class_getInstanceVariable(coder.class, "_canvas");
+    CGContextRef canvas = ((CGContextRef (*)(id, Ivar))object_getIvar)(coder, ivar);
+    XCTAssert(canvas == NULL);
 }
 
 @end


### PR DESCRIPTION
This is a quick fix for #29.

For Static WebP, we don't create extra CGContext to consume RAM. Instead, just do the static WebP decoding.

Note this method still need to be protected in the LOCK/UNLOCK code, because multiple thread can access the `animatedImageFrameAtIndex:`, and we share the global `_demux` instance.

The root solution is in 5.4.2 of SDWebImage, see: https://github.com/SDWebImage/SDWebImage/pull/2924