### PR TITLE
Fix the issue that thumbnail decoding does not works for progressive webp image

### DIFF
--- a/SDWebImageWebPCoder/Classes/SDImageWebPCoder.m
+++ b/SDWebImageWebPCoder/Classes/SDImageWebPCoder.m
@@ -362,6 +362,13 @@ static CGSize SDCalculateThumbnailSize(CGSize fullSize, BOOL preserveAspectRatio
                 scale = 1;
             }
         }
+        CGSize scaledSize = SDCalculateThumbnailSize(CGSizeMake(width, height), _preserveAspectRatio, _thumbnailSize);
+        // Check whether we need to use thumbnail
+        if (!CGSizeEqualToSize(CGSizeMake(width, height), scaledSize)) {
+            CGImageRef scaledImageRef = [SDImageCoderHelper CGImageCreateScaled:newImageRef size:scaledSize];
+            CGImageRelease(newImageRef);
+            newImageRef = scaledImageRef;
+        }
         
 #if SD_UIKIT || SD_WATCH
         image = [[UIImage alloc] initWithCGImage:newImageRef scale:scale orientation:UIImageOrientationUp];


### PR DESCRIPTION
The libwebp progressive API does not have something like `use_scaling`. Sadly :(

So, fallback to use the `CGImageCreatedScaled`