### PR TITLE
Feature - Supports Progressive Animated WebP (Important)

### DIFF
--- a/Example/SDWebImageWebPCoderExample/ViewController.m
+++ b/Example/SDWebImageWebPCoderExample/ViewController.m
@@ -22,6 +22,8 @@
     [super viewDidLoad];
     // Do any additional setup after loading the view, typically from a nib.
     
+    [SDImageCache.sharedImageCache clearDiskOnCompletion:nil];
+    
     [[SDImageCodersManager sharedManager] addCoder:[SDImageWebPCoder sharedCoder]];
     
     self.imageView1 = [UIImageView new];
@@ -46,7 +48,7 @@
             }
         });
     }];
-    [self.imageView2 sd_setImageWithURL:animatedWebPURL completed:^(UIImage * _Nullable image, NSError * _Nullable error, SDImageCacheType cacheType, NSURL * _Nullable imageURL) {
+    [self.imageView2 sd_setImageWithURL:animatedWebPURL placeholderImage:nil options:SDWebImageProgressiveLoad completed:^(UIImage * _Nullable image, NSError * _Nullable error, SDImageCacheType cacheType, NSURL * _Nullable imageURL) {
         if (image) {
             NSLog(@"%@", @"Animated WebP load success");
         }

--- a/SDWebImageWebPCoder/Classes/SDImageWebPCoder.m
+++ b/SDWebImageWebPCoder/Classes/SDImageWebPCoder.m
@@ -347,6 +347,14 @@ static CGSize SDCalculateThumbnailSize(CGSize fullSize, BOOL preserveAspectRatio
 - (UIImage *)incrementalDecodedImageWithOptions:(SDImageCoderOptions *)options {
     UIImage *image;
     
+    // For Animated WebP Images, progressive decoding only return the first frame.
+    // If you want progressive animation, use the SDAniamtedCoder protocol method instead.
+    if (_demux) {
+        SD_LOCK(_lock);
+        image = [self safeStaticImageFrame];
+        SD_UNLOCK(_lock);
+    }
+    // For Static WebP images
     int width = 0;
     int height = 0;
     int last_y = 0;


### PR DESCRIPTION
See the demo video:

[Progressive Animated WebP.mov.zip](https://github.com/SDWebImage/SDWebImageWebPCoder/files/4080406/Progressive.Animated.WebP.mov.zip)

Sample WebP Image (1.2MB): https://static.ezgif.com/images/format-demo/butterfly.webp

Note:
For UIImageView using the `SDWebImageProgressiveLoad`, the decoder will only decode animation first frame image, this keep the exist behavior for GIF/APNG.