### PR TITLE
Upgrade the dependency to SDWebImage 5.7, supports the maxFileSize encoding options, as well as enabling the thread-encoding for speedup

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-github "SDWebImage/SDWebImage" ~> 5.5
+github "SDWebImage/SDWebImage" ~> 5.7
 github "SDWebImage/libwebp-Xcode" ~> 1.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "SDWebImage/SDWebImage" "5.5.0"
+github "SDWebImage/SDWebImage" "5.7.0"
 github "SDWebImage/libwebp-Xcode" "1.1.0"

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
-        .package(url: "https://github.com/SDWebImage/SDWebImage.git", from: "5.5.0"),
+        .package(url: "https://github.com/SDWebImage/SDWebImage.git", from: "5.7.0"),
         .package(url: "https://github.com/SDWebImage/libwebp-Xcode.git", from: "1.1.0")
     ],
     targets: [

--- a/SDWebImageWebPCoder.podspec
+++ b/SDWebImageWebPCoder.podspec
@@ -27,7 +27,7 @@ This is a SDWebImage coder plugin to support WebP image.
     'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) SD_WEBP=1 WEBP_USE_INTRINSICS=1',
     'USER_HEADER_SEARCH_PATHS' => '$(inherited) $(SRCROOT)/libwebp/src'
   }
-  s.dependency 'SDWebImage/Core', '~> 5.5'
+  s.dependency 'SDWebImage/Core', '~> 5.7'
   s.dependency 'libwebp', '~> 1.0'
   
 end


### PR DESCRIPTION
See 5.7.0 feature: [maxFileSize](https://github.com/SDWebImage/SDWebImage/releases/tag/5.7.0)

libwebp Encoding API: https://developers.google.com/speed/webp/docs/api#advanced_encoding_api