### PR TITLE
[WIP] Fix Xcode 12 SPM Error

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "SDWebImageWebPCoder",
     platforms: [
-        .macOS(.v10_10), .iOS(.v8), .tvOS(.v9), .watchOS(.v2)
+        .macOS(.v10_10), .iOS(.v9), .tvOS(.v9), .watchOS(.v2)
     ],
     products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.


### PR DESCRIPTION
Addresses the error below. It appears in Xcode 12 because 12 drops support for iOS 8.0. Going this far to update Package.swift, I might as well drop support in Cocoapods + Carthage for iOS 8.0....

`The iOS Simulator deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 8.0, but the range of supported deployment target versions is 9.0 to 14.0.99.`

[libwebp-Xcode - Package.swift](https://github.com/SDWebImage/libwebp-Xcode/blob/master/Package.swift) doesn't happen an explicit minimum deployment target, therefore it is set to iOS 9.0 in Xcode 12, causing the error above.


## Possible Solutions
1. Drop support for iOS 8 and make minimum deployment target iOS 9
2. Explicitly make [libwebp-Xcode - Package.swift](https://github.com/SDWebImage/libwebp-Xcode/blob/master/Package.swift) supply iOS 8 as minimum deployment target

iOS 8 came out in 2014 and likely many app don't even support it anymore, so I think 1. makes more sense, but it should be a decision made project wide for each library under the SDWebImage instead of making changes in piecemeal, which would be more confusing.