### PR TITLE
Fix the encoding maxPixelSize logic using 5.13.0 API

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-github "SDWebImage/SDWebImage" ~> 5.10
+github "SDWebImage/SDWebImage" ~> 5.13
 github "SDWebImage/libwebp-Xcode" ~> 1.0

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
-        .package(url: "https://github.com/SDWebImage/SDWebImage.git", from: "5.10.0"),
+        .package(url: "https://github.com/SDWebImage/SDWebImage.git", from: "5.13.0"),
         .package(url: "https://github.com/SDWebImage/libwebp-Xcode.git", from: "1.1.0")
     ],
     targets: [

--- a/Podfile
+++ b/Podfile
@@ -8,6 +8,7 @@ target 'SDWebImageWebPCoderExample' do
   platform :ios, '9.0'
   project example_project_path
   pod 'SDWebImageWebPCoder', :path => './'
+  pod 'SDWebImage', :path => '../SDWebImage'
 end
 
 target 'SDWebImageWebPCoderTests' do
@@ -15,4 +16,5 @@ target 'SDWebImageWebPCoderTests' do
   project test_project_path
   pod 'Expecta'
   pod 'SDWebImageWebPCoder', :path => './'
+  pod 'SDWebImage', :path => '../SDWebImage'
 end

--- a/SDWebImageWebPCoder.podspec
+++ b/SDWebImageWebPCoder.podspec
@@ -27,7 +27,7 @@ This is a SDWebImage coder plugin to support WebP image.
     'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) SD_WEBP=1 WEBP_USE_INTRINSICS=1',
     'USER_HEADER_SEARCH_PATHS' => '$(inherited) $(SRCROOT)/libwebp/src'
   }
-  s.dependency 'SDWebImage/Core', '~> 5.10'
+  s.dependency 'SDWebImage/Core', '~> 5.13'
   s.dependency 'libwebp', '~> 1.0'
   
 end


### PR DESCRIPTION
This using the new calculation from SDWebImage Core, which bump the minor version (0.9.0+)

This depends on https://github.com/SDWebImage/SDWebImage/pull/3359