### PR TITLE
Fix the encoding maxPixelSize logic (patch)

### DIFF
--- a/SDWebImageWebPCoder/Classes/SDImageWebPCoder.m
+++ b/SDWebImageWebPCoder/Classes/SDImageWebPCoder.m
@@ -860,7 +860,7 @@ static CGSize SDCalculateThumbnailSize(CGSize fullSize, BOOL preserveAspectRatio
     }
     
     // Check if need to scale pixel size
-    if (maxPixelSize.width > 0 && maxPixelSize.height > 0 && width > maxPixelSize.width && height > maxPixelSize.height) {
+    if (maxPixelSize.width > 0 && maxPixelSize.height > 0 && (width > maxPixelSize.width || height > maxPixelSize.height)) {
         CGSize scaledSize = SDCalculateThumbnailSize(CGSizeMake(width, height), YES, maxPixelSize);
         result = WebPPictureRescale(&picture, scaledSize.width, scaledSize.height);
         if (!result) {


### PR DESCRIPTION
This quickly fix the #64, without bumping the SDWebImage Core dependency version