### PR TITLE
Reduce memory usage peak when using thumbnail animated WebP decoding and encoding

### DIFF
--- a/Example/SDWebImageWebPCoderExample/ViewController.m
+++ b/Example/SDWebImageWebPCoderExample/ViewController.m
@@ -37,10 +37,10 @@
     NSURL *staticWebPURL = [NSURL URLWithString:@"http://littlesvr.ca/apng/images/SteamEngine.webp"];
     NSURL *animatedWebPURL = [NSURL URLWithString:@"http://littlesvr.ca/apng/images/SteamEngine.webp?foo=bar"];
     
-    [self.imageView1 sd_setImageWithURL:staticWebPURL placeholderImage:nil options:0 context:@{SDWebImageContextImageThumbnailPixelSize : @(CGSizeMake(300, 300))} progress:nil completed:^(UIImage * _Nullable image, NSError * _Nullable error, SDImageCacheType cacheType, NSURL * _Nullable imageURL) {
-    }];
-    NSDictionary *decodeOptions = @{SDWebImageContextImageThumbnailPixelSize : @(CGSizeMake(300, 300)), SDImageCoderDecodeUseLazyDecoding: @(YES)}; // <---
-    [self.imageView2 sd_setImageWithURL:animatedWebPURL placeholderImage:nil options:0 context:@{SDWebImageContextImageDecodeOptions : decodeOptions} progress:nil completed:^(UIImage * _Nullable image, NSError * _Nullable error, SDImageCacheType cacheType, NSURL * _Nullable imageURL) {
+//    [self.imageView1 sd_setImageWithURL:staticWebPURL placeholderImage:nil options:0 context:@{SDWebImageContextImageThumbnailPixelSize : @(CGSizeMake(300, 300))} progress:nil completed:^(UIImage * _Nullable image, NSError * _Nullable error, SDImageCacheType cacheType, NSURL * _Nullable imageURL) {
+//    }];
+    NSDictionary *decodeOptions = @{SDImageCoderDecodeThumbnailPixelSize : @(CGSizeMake(300, 300)), SDImageCoderDecodeUseLazyDecoding: @(YES)}; // <---
+    [self.imageView2 sd_setImageWithURL:animatedWebPURL placeholderImage:nil options:0 context:@{SDWebImageContextImageDecodeOptions : decodeOptions, SDWebImageContextImageThumbnailPixelSize : @(CGSizeMake(300, 300))} progress:nil completed:^(UIImage * _Nullable image, NSError * _Nullable error, SDImageCacheType cacheType, NSURL * _Nullable imageURL) {
     }];
 }
 

--- a/Example/SDWebImageWebPCoderExample/ViewController.m
+++ b/Example/SDWebImageWebPCoderExample/ViewController.m
@@ -26,7 +26,7 @@
     
     [[SDImageCodersManager sharedManager] addCoder:[SDImageWebPCoder sharedCoder]];
     
-    self.imageView1 = [UIImageView new];
+    self.imageView1 = [SDAnimatedImageView new];
     self.imageView1.contentMode = UIViewContentModeScaleAspectFit;
     [self.view addSubview:self.imageView1];
     
@@ -34,26 +34,13 @@
     self.imageView2.contentMode = UIViewContentModeScaleAspectFit;
     [self.view addSubview:self.imageView2];
     
-    NSURL *staticWebPURL = [NSURL URLWithString:@"https://www.gstatic.com/webp/gallery/2.webp"];
-    NSURL *animatedWebPURL = [NSURL URLWithString:@"http://littlesvr.ca/apng/images/world-cup-2014-42.webp"];
+    NSURL *staticWebPURL = [NSURL URLWithString:@"http://littlesvr.ca/apng/images/SteamEngine.webp"];
+    NSURL *animatedWebPURL = [NSURL URLWithString:@"http://littlesvr.ca/apng/images/SteamEngine.webp?foo=bar"];
     
     [self.imageView1 sd_setImageWithURL:staticWebPURL placeholderImage:nil options:0 context:@{SDWebImageContextImageThumbnailPixelSize : @(CGSizeMake(300, 300))} progress:nil completed:^(UIImage * _Nullable image, NSError * _Nullable error, SDImageCacheType cacheType, NSURL * _Nullable imageURL) {
-        if (image) {
-            NSLog(@"%@", @"Static WebP load success");
-        }
-        dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-            NSUInteger maxFileSize = 4096;
-            NSData *webpData = [SDImageWebPCoder.sharedCoder encodedDataWithImage:image format:SDImageFormatWebP options:@{SDImageCoderEncodeMaxFileSize : @(maxFileSize)}];
-            if (webpData) {
-                NSCAssert(webpData.length <= maxFileSize, @"WebP Encoding with max file size limit works");
-                NSLog(@"%@", @"WebP encoding success");
-            }
-        });
     }];
-    [self.imageView2 sd_setImageWithURL:animatedWebPURL placeholderImage:nil options:SDWebImageProgressiveLoad completed:^(UIImage * _Nullable image, NSError * _Nullable error, SDImageCacheType cacheType, NSURL * _Nullable imageURL) {
-        if (image) {
-            NSLog(@"%@", @"Animated WebP load success");
-        }
+    NSDictionary *decodeOptions = @{SDWebImageContextImageThumbnailPixelSize : @(CGSizeMake(300, 300)), SDImageCoderDecodeUseLazyDecoding: @(YES)}; // <---
+    [self.imageView2 sd_setImageWithURL:animatedWebPURL placeholderImage:nil options:0 context:@{SDWebImageContextImageDecodeOptions : decodeOptions} progress:nil completed:^(UIImage * _Nullable image, NSError * _Nullable error, SDImageCacheType cacheType, NSURL * _Nullable imageURL) {
     }];
 }
 


### PR DESCRIPTION
1. Use CoreGraphics to avoid extra vImage convert and allocate of decoded thumbnail image buffer
2. Use kvImageNoAllocate to avoi extra vImage to allocate 1x memory buffer (x means the input source image buffer)

See more in : https://github.com/SDWebImage/SDWebImage/issues/3508