### PR TITLE
Enable lossless mode

### DIFF
--- a/SDWebImageWebPCoder/Classes/SDImageWebPCoder.m
+++ b/SDWebImageWebPCoder/Classes/SDImageWebPCoder.m
@@ -955,7 +955,7 @@ WEBP_CSP_MODE ConvertCSPMode(CGBitmapInfo bitmapInfo) {
 
     config->target_size = (int)maxFileSize; // Max filesize for output, 0 means use quality instead
     config->pass = maxFileSize > 0 ? 6 : 1; // Use 6 passes for file size limited encoding, which is the default value of `cwebp` command line
-    config->lossless = 0; // Disable lossless encoding (If we need, can add new Encoding Options in future version)
+  config->lossless = GetIntValueForKey(options, SDImageCoderEncodeWebPLossless, config->lossless);
     
     config->method = GetIntValueForKey(options, SDImageCoderEncodeWebPMethod, config->method);
     config->pass = GetIntValueForKey(options, SDImageCoderEncodeWebPPass, config->pass);

--- a/SDWebImageWebPCoder/Classes/SDImageWebPCoder.m
+++ b/SDWebImageWebPCoder/Classes/SDImageWebPCoder.m
@@ -955,7 +955,7 @@ WEBP_CSP_MODE ConvertCSPMode(CGBitmapInfo bitmapInfo) {
 
     config->target_size = (int)maxFileSize; // Max filesize for output, 0 means use quality instead
     config->pass = maxFileSize > 0 ? 6 : 1; // Use 6 passes for file size limited encoding, which is the default value of `cwebp` command line
-  config->lossless = GetIntValueForKey(options, SDImageCoderEncodeWebPLossless, config->lossless);
+    config->lossless = GetIntValueForKey(options, SDImageCoderEncodeWebPLossless, config->lossless);
     
     config->method = GetIntValueForKey(options, SDImageCoderEncodeWebPMethod, config->method);
     config->pass = GetIntValueForKey(options, SDImageCoderEncodeWebPPass, config->pass);

--- a/SDWebImageWebPCoder/Classes/SDWebImageWebPCoderDefine.h
+++ b/SDWebImageWebPCoder/Classes/SDWebImageWebPCoderDefine.h
@@ -133,7 +133,7 @@ FOUNDATION_EXPORT SDImageCoderOption _Nonnull const SDImageCoderEncodeWebPPartit
 FOUNDATION_EXPORT SDImageCoderOption _Nonnull const SDImageCoderEncodeWebPUseSharpYuv;
 
 /**
- 0: Diabled, 1: Enabled.
+ 0: Disabled, 1: Enabled.
  Lossless mode. Note that if lossless is enabled, encoder quality param specifies
  compression effort. 100 means maximum compression.
  */

--- a/SDWebImageWebPCoder/Classes/SDWebImageWebPCoderDefine.h
+++ b/SDWebImageWebPCoder/Classes/SDWebImageWebPCoderDefine.h
@@ -132,4 +132,11 @@ FOUNDATION_EXPORT SDImageCoderOption _Nonnull const SDImageCoderEncodeWebPPartit
  */
 FOUNDATION_EXPORT SDImageCoderOption _Nonnull const SDImageCoderEncodeWebPUseSharpYuv;
 
+/**
+ 0: Diabled, 1: Enabled.
+ Lossless mode. Note that if lossless is enabled, encoder quality param specifies
+ compression effort. 100 means maximum compression.
+ */
+FOUNDATION_EXPORT SDImageCoderOption _Nonnull const SDImageCoderEncodeWebPLossless;
+
 NS_ASSUME_NONNULL_END

--- a/SDWebImageWebPCoder/Classes/SDWebImageWebPCoderDefine.h
+++ b/SDWebImageWebPCoder/Classes/SDWebImageWebPCoderDefine.h
@@ -136,6 +136,7 @@ FOUNDATION_EXPORT SDImageCoderOption _Nonnull const SDImageCoderEncodeWebPUseSha
  0: Disabled, 1: Enabled.
  Lossless mode. Note that if lossless is enabled, encoder quality param specifies
  compression effort. 100 means maximum compression.
+ Details on cwebp documentation: https://developers.google.com/speed/webp/docs/cwebp#lossless
  */
 FOUNDATION_EXPORT SDImageCoderOption _Nonnull const SDImageCoderEncodeWebPLossless;
 

--- a/SDWebImageWebPCoder/Classes/SDWebImageWebPCoderDefine.m
+++ b/SDWebImageWebPCoder/Classes/SDWebImageWebPCoderDefine.m
@@ -26,3 +26,4 @@ SDImageCoderOption _Nonnull const SDImageCoderEncodeWebPShowCompressed = @"webPS
 SDImageCoderOption _Nonnull const SDImageCoderEncodeWebPPartitions = @"webPPartitions";
 SDImageCoderOption _Nonnull const SDImageCoderEncodeWebPPartitionLimit = @"webPPartitionLimit";
 SDImageCoderOption _Nonnull const SDImageCoderEncodeWebPUseSharpYuv = @"webPUseSharpYuv";
+SDImageCoderOption _Nonnull const SDImageCoderEncodeWebPLossless = @"webPLossless";

--- a/Tests/SDWebImageWebPCoderTests.m
+++ b/Tests/SDWebImageWebPCoderTests.m
@@ -252,7 +252,8 @@ const int64_t kAsyncTestTimeout = 5;
                                       SDImageCoderEncodeWebPShowCompressed: @16,
                                       SDImageCoderEncodeWebPPartitions: @17,
                                       SDImageCoderEncodeWebPPartitionLimit: @18,
-                                      SDImageCoderEncodeWebPUseSharpYuv: @19 };
+                                      SDImageCoderEncodeWebPUseSharpYuv: @19,
+                                      SDImageCoderEncodeWebPLossless: @1 };
 
     [SDImageWebPCoder.sharedCoder updateWebPOptionsToConfig:&config maxFileSize:1200 options:options];
 
@@ -275,6 +276,7 @@ const int64_t kAsyncTestTimeout = 5;
     expect(config.partitions).to.equal(17);
     expect(config.partition_limit).to.equal(18);
     expect(config.use_sharp_yuv).to.equal(19);
+    expect(config.lossless).to.equal(1);
 }
 
 - (void)testEncodingSettingsDefaultValue {


### PR DESCRIPTION
This PR adds a `SDImageCoderEncodeWebPLossless` option to enable lossless mode on webp encoder.