### PR TITLE
Support to detect the RGB16 bitmap info, fix the iOS 11- decode issues

### DIFF
--- a/SDWebImageWebPCoder/Classes/SDImageWebPCoder.m
+++ b/SDWebImageWebPCoder/Classes/SDImageWebPCoder.m
@@ -632,7 +632,7 @@ WEBP_CSP_MODE ConvertCSPMode(CGBitmapInfo bitmapInfo) {
 #endif
         // Fallback to RGBA8888/RGB888 instead
         mode = MODE_rgbA;
-        CGBitmapInfo bitmapInfo = kCGBitmapByteOrderDefault;
+        bitmapInfo = kCGBitmapByteOrderDefault;
         bitmapInfo |= hasAlpha ? kCGImageAlphaPremultipliedLast : kCGImageAlphaNoneSkipLast;
     }
     config.output.colorspace = mode;


### PR DESCRIPTION
### Changes

Also, fallback when the libwebp don't support the target bitmap info, should not just return nil

This close #86 