### PR TITLE
Fix the issue when monochome colorspace cause the WebP encoding failed

### DIFF
--- a/SDWebImageWebPCoder/Classes/SDImageWebPCoder.m
+++ b/SDWebImageWebPCoder/Classes/SDImageWebPCoder.m
@@ -885,6 +885,12 @@ WEBP_CSP_MODE ConvertCSPMode(CGBitmapInfo bitmapInfo) {
     uint8_t *rgba = NULL; // RGBA Buffer managed by CFData, don't call `free` on it, instead call `CFRelease` on `dataRef`
     // We must prefer the input CGImage's color space, which may contains ICC profile
     CGColorSpaceRef colorSpace = CGImageGetColorSpace(imageRef);
+    // We only supports RGB colorspace, filter the un-supported one (like Monochrome, CMYK, etc)
+    if (CGColorSpaceGetModel(colorSpace) != kCGColorSpaceModelRGB) {
+        // Ignore and convert, we don't know how to encode this colorspace directlly to WebP
+        // This may cause little visible difference because of colorpsace conversion
+        colorSpace = NULL;
+    }
     if (!colorSpace) {
         colorSpace = [SDImageCoderHelper colorSpaceGetDeviceRGB];
     }

--- a/Tests/SDWebImageWebPCoderTests.m
+++ b/Tests/SDWebImageWebPCoderTests.m
@@ -218,6 +218,21 @@ const int64_t kAsyncTestTimeout = 5;
     XCTAssertLessThanOrEqual(dataWithLimit.length, maxFileSize);
 }
 
+- (void)test46WebPEncodingMonochrome {
+    CGSize size = CGSizeMake(512, 512);
+    SDGraphicsImageRendererFormat *format = [[SDGraphicsImageRendererFormat alloc] init];
+    format.scale = 1;
+    SDGraphicsImageRenderer *renderer = [[SDGraphicsImageRenderer alloc] initWithSize:size format:format];
+    UIColor *monochromeColor = UIColor.clearColor;
+    UIImage *monochromeImage = [renderer imageWithActions:^(CGContextRef ctx) {
+        [monochromeColor setFill];
+        CGContextFillRect(ctx, CGRectMake(0, 0, size.width, size.height));
+    }];
+    XCTAssert(monochromeImage);
+    NSData *data = [SDImageWebPCoder.sharedCoder encodedDataWithImage:monochromeImage format:SDImageFormatWebP options:nil];
+    XCTAssert(data);
+}
+
 - (void)testWebPDecodeDoesNotTriggerCACopyImage {
     NSURL *staticWebPURL = [[NSBundle bundleForClass:[self class]] URLForResource:@"TestColorspaceStatic" withExtension:@"webp"];
     NSData *data = [NSData dataWithContentsOfURL:staticWebPURL];

--- a/Tests/SDWebImageWebPCoderTests.m
+++ b/Tests/SDWebImageWebPCoderTests.m
@@ -371,10 +371,18 @@ const int64_t kAsyncTestTimeout = 5;
     CGFloat r1;
     CGFloat g1;
     CGFloat b1;
+#if SD_UIKIT
     [color1 getRed:&r1 green:&g1 blue:&b1 alpha:nil];
     expect(255 * r1).beCloseToWithin(0, 5);
     expect(255 * g1).beCloseToWithin(38, 5);
     expect(255 * b1).beCloseToWithin(135, 5);
+#else
+    @try {
+        [color1 getRed:&r1 green:&g1 blue:&b1 alpha:nil];
+    }
+    @catch (NSException *exception) {}
+    expect(255 * r1).beCloseToWithin(0, 5);
+#endif
 }
 
 @end


### PR DESCRIPTION
Just translate into RGBA first, don't need extra code to re-implements monochrome WebP encoding

This close #94 