### PR TITLE
Move the test case `testWebPDecodeDoesNotTriggerCACopyImage` into the WebP repo

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -1,6 +1,5 @@
 install! "cocoapods",
-         :generate_multiple_pod_projects => true,
-         :incremental_installation => true
+         :generate_multiple_pod_projects => true
          
 use_frameworks!
 
@@ -32,4 +31,27 @@ target 'SDWebImageWebPCoderTests-macOS' do
   project test_project_path
   pod 'Expecta'
   pod 'SDWebImageWebPCoder', :path => './'
+end
+
+
+# Inject macro during SDWebImage Demo and Tests
+post_install do |installer_representation|
+  installer_representation.generated_projects.each do |project|
+    project.targets.each do |target|
+      if target.product_name == 'SDWebImageWebPCoder'
+        target.build_configurations.each do |config|
+          config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] = '$(inherited) SD_CHECK_CGIMAGE_RETAIN_SOURCE=1'
+        end
+      else
+        target.build_configurations.each do |config|
+          # Override the min deployment target for some test specs to workaround `libarclite.a` missing issue
+          config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '9.0'
+          config.build_settings['MACOSX_DEPLOYMENT_TARGET'] = '10.11'
+          config.build_settings['TVOS_DEPLOYMENT_TARGET'] = '9.0'
+          config.build_settings['WATCHOS_DEPLOYMENT_TARGET'] = '2.0'
+          config.build_settings['XROS_DEPLOYMENT_TARGET'] = '1.0'
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Also, fix the min deployment target of `Expecta`

This is needed for passing unit test during https://github.com/SDWebImage/SDWebImage/pull/3678