### PR TITLE
FIX: _limitBytes type error

### DIFF
--- a/SDWebImageWebPCoder/Classes/SDImageWebPCoder.m
+++ b/SDWebImageWebPCoder/Classes/SDImageWebPCoder.m
@@ -174,7 +174,7 @@ WEBP_CSP_MODE ConvertCSPMode(CGBitmapInfo bitmapInfo) {
     NSUInteger _currentBlendIndex;
     BOOL _preserveAspectRatio;
     CGSize _thumbnailSize;
-    BOOL _limitBytes;
+    NSUInteger _limitBytes;
 }
 
 - (void)dealloc {


### PR DESCRIPTION
NSUInteger limitBytes = 0;
NSNumber *limitBytesValue = options[SDImageCoderDecodeScaleDownLimitBytes];
if (limitBytesValue != nil) {
limitBytes = limitBytesValue.unsignedIntegerValue;
}
_limitBytes = limitBytes; ❌❌❌ **ERROR: limitBytes = 62914560, but _limitBytes = 1。**❌❌❌
// Scale down to limit bytes if need
if (_limitBytes > 0) {
// Hack 32 BitsPerPixel
CGSize imageSize = CGSizeMake(_canvasWidth, _canvasHeight);
CGSize framePixelSize = SDCalculateScaleDownPixelSize(_limitBytes, imageSize, _frameCount, 4);
// Override thumbnail size
_thumbnailSize = framePixelSize;
_preserveAspectRatio = YES;
}

![image](https://github.com/SDWebImage/SDWebImageWebPCoder/assets/11459928/2b55ec65-4945-482e-8803-90987fe5ad26)
